### PR TITLE
feature: diagram type 추가

### DIFF
--- a/src/__mocks__/data.ts
+++ b/src/__mocks__/data.ts
@@ -1,5 +1,6 @@
 import {MoaText} from "@/types/document";
 import {User} from "@/types/user";
+import {Diagram} from "@/types/diagram";
 
 export const testData: Array<MoaText> = [
   {
@@ -36,4 +37,14 @@ export const testUser: Array<User> = [
     uuid: "83942e5e-0399-4c08-bab5-b775938a2951",
     name: "son"
   },
+];
+
+export const testDiagram: Array<Diagram> = [
+  {
+    uuid: "23942d5e-0399-4c08-bab5-b175938a2951",
+    title: "테스트 Diagram 1",
+    elements: [
+      
+    ]
+  }
 ];

--- a/src/app/doc/d/[uuid]/page.tsx
+++ b/src/app/doc/d/[uuid]/page.tsx
@@ -1,0 +1,10 @@
+import DiagramRenderer from "@/components/diagram/DiagramRenderer";
+
+export default async function Diagram({params}: { params: { uuid: string } }) {
+  const {uuid} = await params;
+  return (
+    <div className={"max-w-4xl h-[500px] mx-auto bg-white p-5 shadow-md"}>
+      <DiagramRenderer uuid={uuid} />
+    </div>
+  );
+}

--- a/src/components/diagram/DiagramRenderer.tsx
+++ b/src/components/diagram/DiagramRenderer.tsx
@@ -1,0 +1,17 @@
+"use client"
+import dynamic from "next/dynamic";
+
+const ExcalidrawWrapper = dynamic(
+  async () => (await import("./ExcalidrawWrapper")).default,
+  {
+    ssr: false,
+  },
+);
+
+export default function DiagramRenderer({uuid}:{uuid:string}) {
+  return (
+    <div className={"w-full h-full"} key={uuid}>
+      <ExcalidrawWrapper />
+    </div>
+  );
+}

--- a/src/components/diagram/ExcalidrawWrapper.tsx
+++ b/src/components/diagram/ExcalidrawWrapper.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { Excalidraw } from "@excalidraw/excalidraw";
+
+import "@excalidraw/excalidraw/index.css";
+
+const ExcalidrawWrapper: React.FC<{onChange?:()=>void}> = ({onChange}) => {
+  return (
+    <div className={"w-full h-full"}>
+      <Excalidraw
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+export default ExcalidrawWrapper;

--- a/src/types/diagram.d.ts
+++ b/src/types/diagram.d.ts
@@ -1,0 +1,8 @@
+import { ExcalidrawElement } from "@excalidraw/excalidraw";
+//import { AppState } from "@excalidraw/excalidraw";
+
+export interface Diagram {
+  uuid: string,
+  title: string,
+  elements: Array<ExcalidrawElement>
+}


### PR DESCRIPTION
feature: diagram page, Renderer 추가
feature: diagram test data 추가

- ExcalidrawElement[]를 저장하는 형태의 Diagram type을 diagram.d.ts에 정의
- DiagramWrapper 및 DiagramRenderer 추가
- Diagram을 저장하는 test data를 __mocks__에 추가