### PR TITLE
[Feature] BE 에서 수정된 subscribe destination 에 대응하여 `useDocumentSync.ts` 수정

### DIFF
--- a/src/components/document/DocumentRenderer.tsx
+++ b/src/components/document/DocumentRenderer.tsx
@@ -8,7 +8,7 @@ import DocumentTitle from "@/components/document/DocumentTitle";
 import useDocumentSync from "@/hooks/useDocumentSync";
 
 export default function DocumentRenderer({user, uuid}: { user:User, uuid: string }) {
-  const [document, setDocument] = useState<Note>({title: uuid, id: uuid, content: "편집하려면 여기 클릭"}); // 현재 문서 내용
+  const [document, setDocument] = useState<Note>({title: uuid, id: uuid, content: ""}); // 현재 문서 내용
   const [isEditing, setEditing] = useState<boolean>(false); // 현재 편집중인가?
 
   const startEditing = () => setEditing(true);

--- a/src/hooks/useDocumentSync.ts
+++ b/src/hooks/useDocumentSync.ts
@@ -26,6 +26,11 @@ const useDocumentSync = (user:User, uuid:string, update:(content: string)=>void)
       debugToast(`received l[${timestampRef.current}] r[${received.timeStamp}] ${received.value.content}`, {position:"bottom-right"});
     }
   };
+  const init = (received:{stateId:string, timeStamp: number, value:{content:string}}) => {
+    update(received.value.content);
+    timestampRef.current = received.timeStamp;
+    debugToast(`received l[${timestampRef.current}] r[${received.timeStamp}] ${received.value.content}`, {position:"bottom-right"});
+  };
   const publish = (content: string) => {
     if (clientRef.current && clientRef.current.connected) {
       const updatedTimestamp = timestampRef.current + 1;
@@ -47,7 +52,7 @@ const useDocumentSync = (user:User, uuid:string, update:(content: string)=>void)
         client.subscribe(`/app/docs/participate/${docsSubWith.docId}`, message => {
           try {
             const body = JSON.parse(message.body);
-            sync(body);
+            init(body);
           } catch {
             // body not fit
             toast.error("받은 정보의 body가 불충분함");

--- a/src/hooks/useDocumentSync.ts
+++ b/src/hooks/useDocumentSync.ts
@@ -44,7 +44,7 @@ const useDocumentSync = (user:User, uuid:string, update:(content: string)=>void)
       onConnect: () => {
         if (process.env.DEBUG==='true')
           toast("연결시도 끝");
-        client.subscribe(`/app/docs/${docsSubWith.docId}`, message => {
+        client.subscribe(`/app/docs/participate/${docsSubWith.docId}`, message => {
           try {
             const body = JSON.parse(message.body);
             sync(body);
@@ -53,6 +53,15 @@ const useDocumentSync = (user:User, uuid:string, update:(content: string)=>void)
             toast.error("받은 정보의 body가 불충분함");
           }
         }, {'participantUserId': docsSubWith['userId']});
+        client.subscribe(`/topic/docs/${docsSubWith.docId}`, (message) => {
+          try {
+              const body = JSON.parse(message.body);
+              sync(body);
+          } catch {
+              // body not fit
+              toast.error("받은 정보의 body가 불충분함");
+          }
+        });
       },
       onWebSocketError: (event) => {
         toast.error("서버와의 연결이 실패하였습니다.",{position:"bottom-right"});

--- a/src/hooks/useDocumentSync.ts
+++ b/src/hooks/useDocumentSync.ts
@@ -15,7 +15,6 @@ const SERVER_WS_URL = process.env.NEXT_PUBLIC_SERVER_WS_URL;
 const useDocumentSync = (user:User, uuid:string, update:(content: string)=>void) => {
   const timestampRef = useRef<number>(0);
   const clientRef = useRef<Client | null>(null);
-  // TODO@ : 이 부분은 나중에 서버에서 받아온 uuid로 바꿔야함
   const docsSubWith = {
     'docId': uuid,
     'userId': user.id,


### PR DESCRIPTION
## 수행한 작업
### chore
- 해결된 todo 주석 삭제 9b181cf
### feat
- BE 에서 변경된 subscribe destination 에 대응 f95e561

## 설명
- https://github.com/CBNU-MoaNote-CapstonDesign/backend/issues/51 에서 #37 PR 설명에 적힌 이슈에 대응하여, subscribe destination 이 변경되었습니다.
- 본 PR 은 https://github.com/CBNU-MoaNote-CapstonDesign/backend/issues/51 에 대응하여 `useDocumentSync.ts` 를 수정합니다.

## 관련 이슈
- #37 PR 설명에 적힌 이슈
- https://github.com/CBNU-MoaNote-CapstonDesign/backend/issues/51