### PR TITLE
[Feature] `MarkdownEditor` 는 이제 커서 위치를 추적하며, `DocumentRenderer` 는 커서 위치를 기억함

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-textarea-autosize": "^8.5.9",
-        "stompjs": "^2.3.3"
+        "stompjs": "^2.3.3",
+        "tiny-invariant": "^1.3.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -9234,6 +9235,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-markdown": "^10.1.0",
     "stompjs": "^2.3.3",
     "react-icons": "^5.5.0",
-    "react-textarea-autosize": "^8.5.9"
+    "react-textarea-autosize": "^8.5.9",
+    "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/document/DocumentRenderer.tsx
+++ b/src/components/document/DocumentRenderer.tsx
@@ -10,6 +10,7 @@ import useDocumentSync from "@/hooks/useDocumentSync";
 export default function DocumentRenderer({user, uuid}: { user:User, uuid: string }) {
   const [document, setDocument] = useState<Note>({title: uuid, id: uuid, content: ""}); // 현재 문서 내용
   const [isEditing, setEditing] = useState<boolean>(false); // 현재 편집중인가?
+  const [cursorPosition, setCursorPosition] = useState<number>(0); // 커서 위치
 
   const startEditing = () => setEditing(true);
   const endEditing = () => setEditing(false);
@@ -40,6 +41,8 @@ export default function DocumentRenderer({user, uuid}: { user:User, uuid: string
           updateContent={(content) => {
             send(content);
           }}
+          lastCursorPosition={cursorPosition}
+          cursorHandler={setCursorPosition}
         />
       ) : (
         <MarkdownRenderer

--- a/src/components/document/MarkdownEditor.tsx
+++ b/src/components/document/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import invariant from 'tiny-invariant';
 import {useEffect, useRef, useState} from "react";
 import TextareaAutosize from "react-textarea-autosize";
 //import toast from "react-hot-toast";
@@ -25,6 +26,7 @@ export function MarkdownEditor({initialContent, updateContent = null, updateBlur
 
   const handleSelect = () => {
     const el = textAreaRef.current;
+    invariant(el, "textAreaRef is null");
     if (el) {
       setCursor(el.selectionStart);
       cursorHandler(el.selectionStart);

--- a/src/components/document/MarkdownEditor.tsx
+++ b/src/components/document/MarkdownEditor.tsx
@@ -7,23 +7,28 @@ import TextareaAutosize from "react-textarea-autosize";
  * @param initialContent 초기 내용
  * @param updateContent 사용자가 내용 업데이트할 때 콜백, 상위 컴포넌트에서 서버로 업데이트 해야 함
  * @param updateBlur 사용자가 에디터의 포커스를 잃었을 때 콜백
+ * @param lastCursorPosition 커서 위치 초기값
+ * @param cursorHandler 커서 위치를 상위 컴포넌트로 전달하는 콜백
  * @constructor
- * TODO : 상위 컴포넌트에서 커서 state를 보내서 여기서 useEffect로 커서가 제어되어야 함
  */
-export function MarkdownEditor({initialContent, updateContent = null, updateBlur = null}: {
+export function MarkdownEditor({initialContent, updateContent = null, updateBlur = null, lastCursorPosition, cursorHandler}: {
   initialContent: string | null | undefined,
   updateContent?: null | ((content: string) => void),
-  updateBlur?: null | (() => void)
+  updateBlur?: null | (() => void),
+  lastCursorPosition: number,
+  cursorHandler: ((cursor: number) => void)
 }) {
 
-  const [, setCursor] = useState(0);
   const [content, setContent] = useState(initialContent ? initialContent : "");
+  const [cursorPosition, setCursor] = useState(lastCursorPosition);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleCursor = () => {
+  const handleSelect = () => {
     const el = textAreaRef.current;
-    if (el)
+    if (el) {
       setCursor(el.selectionStart);
+      cursorHandler(el.selectionStart);
+    }
   }
 
   useEffect(() => {
@@ -31,6 +36,13 @@ export function MarkdownEditor({initialContent, updateContent = null, updateBlur
       updateContent(content);
     }
   }, [content]);
+
+  useEffect(() => {
+    if (textAreaRef.current) {
+      textAreaRef.current.focus();
+      textAreaRef.current.setSelectionRange(cursorPosition, cursorPosition);
+    }
+  }, [cursorPosition, textAreaRef]);
 
   // TODO : change 발생 시 api 로 백엔드 호출해 적용시키기, 상위 컴포넌트에서 할 것
   const handleChange = () => {
@@ -54,7 +66,7 @@ export function MarkdownEditor({initialContent, updateContent = null, updateBlur
         value={content ? content : ""}
         onBlur={handleBlur}
         onChange={handleChange}
-        onSelect={handleCursor}
+        onSelect={handleSelect}
         ref={textAreaRef}
         autoFocus={true}/>
     </div>


### PR DESCRIPTION
## 수행한 작업
### deps
- `tiny-invariant` 의존성 추가; dev mode 에서만 동작하는 assert be18837a6566ea1751be74b72fbdd2dc1f88de77
### feat
- `MarkdownEditor` 에서 커서 위치를 추적하게 함 7743d0198d59f89a1a0ca15b9b049590d121e615

## 설명
- `DocumentRenderer` 의 `isEditing` 이 False 가 되어 `MarkdownEditor` 가 일단 unmount 되더라도, 커서 위치를 기억하여 `MarkdownEditor`가 다시 mount 될 시에 커서 위치를 복원합니다.
- 개발 시 편의성 및 유지 보수를 용이하게 하기 위해 `assert` 기능이 필요하여 `tiny-invariant` 를 추가하였습니다

## 관련 이슈
- #44