### PR TITLE
[Bug] `documentRenderer` 컴포넌트에서 에디터 활성화 시에 수정을 하지 않았음 에도 수정 사항을 전파하는 현상 해결

### DIFF
--- a/src/components/document/MarkdownEditor.tsx
+++ b/src/components/document/MarkdownEditor.tsx
@@ -6,7 +6,7 @@ import TextareaAutosize from "react-textarea-autosize";
 /**
  * 마크다운 에디터
  * @param initialContent 초기 내용
- * @param updateContent 사용자가 내용 업데이트할 때 콜백, 상위 컴포넌트에서 서버로 업데이트 해야 함
+ * @param updateContent 에디터에서 내용 업데이트할 때 콜백
  * @param updateBlur 사용자가 에디터의 포커스를 잃었을 때 콜백
  * @param lastCursorPosition 커서 위치 초기값
  * @param cursorHandler 커서 위치를 상위 컴포넌트로 전달하는 콜백
@@ -20,7 +20,6 @@ export function MarkdownEditor({initialContent, updateContent = null, updateBlur
   cursorHandler: ((cursor: number) => void)
 }) {
 
-  const [content, setContent] = useState(initialContent ? initialContent : "");
   const [cursorPosition, setCursor] = useState(lastCursorPosition);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -34,12 +33,6 @@ export function MarkdownEditor({initialContent, updateContent = null, updateBlur
   }
 
   useEffect(() => {
-    if (updateContent) {
-      updateContent(content);
-    }
-  }, [content]);
-
-  useEffect(() => {
     if (textAreaRef.current) {
       textAreaRef.current.focus();
       textAreaRef.current.setSelectionRange(cursorPosition, cursorPosition);
@@ -49,8 +42,8 @@ export function MarkdownEditor({initialContent, updateContent = null, updateBlur
   // TODO : change 발생 시 api 로 백엔드 호출해 적용시키기, 상위 컴포넌트에서 할 것
   const handleChange = () => {
     const el = textAreaRef.current;
-    if (el) {
-      setContent(el.value);
+    if (el && updateContent) {
+      updateContent(el.value);
     }
   }
 
@@ -65,7 +58,7 @@ export function MarkdownEditor({initialContent, updateContent = null, updateBlur
         className="w-full border p-2 rounded-xl"
         minRows={5}
         placeholder={"Type Document Here..."}
-        value={content ? content : ""}
+        value={initialContent ? initialContent : ""}
         onBlur={handleBlur}
         onChange={handleChange}
         onSelect={handleSelect}

--- a/src/components/document/MarkdownEditor.tsx
+++ b/src/components/document/MarkdownEditor.tsx
@@ -6,30 +6,31 @@ import TextareaAutosize from "react-textarea-autosize";
 /**
  * 마크다운 에디터
  * @param initialContent 초기 내용
- * @param updateContent 에디터에서 내용 업데이트할 때 콜백
- * @param updateBlur 사용자가 에디터의 포커스를 잃었을 때 콜백
+ * @param updateContent 에디터에서 내용 업데이트할 때 콜백 (optional)
+ * @param updateBlur 사용자가 에디터의 포커스를 잃었을 때 콜백 (optional)
  * @param lastCursorPosition 커서 위치 초기값
- * @param cursorHandler 커서 위치를 상위 컴포넌트로 전달하는 콜백
+ * @param cursorHandler 커서 위치를 상위 컴포넌트로 전달하는 콜백 (optional)
  * @constructor
  */
-export function MarkdownEditor({initialContent, updateContent = null, updateBlur = null, lastCursorPosition, cursorHandler}: {
+export function MarkdownEditor({initialContent = null, updateContent = null, updateBlur = null, lastCursorPosition = null, cursorHandler = null}: {
   initialContent: string | null | undefined,
   updateContent?: null | ((content: string) => void),
   updateBlur?: null | (() => void),
-  lastCursorPosition: number,
-  cursorHandler: ((cursor: number) => void)
+  lastCursorPosition?: number | null | undefined,
+  cursorHandler?: null | ((cursor: number) => void)
 }) {
 
-  const [cursorPosition, setCursor] = useState(lastCursorPosition);
+  const [cursorPosition, setCursor] = useState(lastCursorPosition ? lastCursorPosition : 0);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleSelect = () => {
     const el = textAreaRef.current;
     invariant(el, "textAreaRef is null");
-    if (el) {
-      setCursor(el.selectionStart);
+    if (!el)
+      return;
+    setCursor(el.selectionStart);
+    if (cursorHandler)
       cursorHandler(el.selectionStart);
-    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## 수행한 작업
### fix
- `documentRenderer` 컴포넌트에서 `MarkdownRenderer` 를 클릭 시에 수정 사항을 전파하는 현상 해결 40bfb7ff30cbd3db9af09a5a36ff2181cc6fe0b0

### refactor
- `lastCursorPosition` 과 `cursorHandler` prop 을 optional 로 변경

## 설명
### 버그 수정 과정
- 수정 사항 전파를 제어하기 위한 `needSend` flag 를 `documentRenderer` 의 state 로 관리함
- content 수정에 대한 `useEffect` 를 `MarkdownEditor` 대신 `documentRenderer` 가 수행하도록 함
- `useEffect` 내에서 수정 사항을 전파하도록 함. 이때 `needSend` 가 `true` 일 때만 전파함
- `updateContent` callback 은  `setNeedSend(true)` 를 수행함

## 관련 이슈
- #45

### 추가 정보
- #46 이 병합되면 이 PR 의 base 를 `dev` 로 변경한 후 이 PR 을 Open 합니다