### PR TITLE
홈 화면에서 로그인 페이지로 이동 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,13 +3,6 @@ import "./globals.css";
 import React from "react";
 import { Toaster } from "react-hot-toast";
 
-import TopNavigationBar from "@/components/layout/Home/TopNavigationBar";
-import Main from "@/components/layout/Home/Main"
-import BasicIntroduce from "@/components/layout/Home/BasicIntroduce"
-import MoaAIIntroduce from "@/components/layout/Home/MoaAIIntroduce"
-import Final from "@/components/layout/Home/Final"
-import ContactLinkBar from "@/components/layout/Home/ContactLinkBar"
-
 export const metadata: Metadata = {
 	title: "모아노트",
 	description: "세상의 모든 아이디어를 모아, 모아노트",
@@ -29,17 +22,8 @@ export default function RootLayout({
 			</head>
 
 			<body className={"noto-sans bg-white"}>
-				<div className="flex flex-col justify-start items-center w-full relative gap-[59px] bg-[#f0f8fe]">
-					<Toaster position="bottom-right" />
-					<TopNavigationBar />
-					<Main />
-					<BasicIntroduce />
-					<MoaAIIntroduce />
-					<Final />
-					<ContactLinkBar />
-
-					{/* {children} */}
-				</div>
+				<Toaster position="bottom-right" />
+				{children}
 			</body>
 		</html>
 	);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,16 +1,24 @@
-export default function Login() {
+import { fetchCurrentUserServerSide } from "@/libs/server/user";
+import { redirect } from "next/navigation";
+
+const LOGIN_URL = process.env.NEXT_PUBLIC_LOGIN_URL;
+
+export default async function LoginPage() {
+
+  const user = await fetchCurrentUserServerSide();
+
+  if (!user) {
+    // 미로그인시 백엔드 로그인 페이지로 이동
+    if (LOGIN_URL)
+      redirect(LOGIN_URL);
+  } else {
+    // 로그인 되어있으면 /main 으로 이동
+    redirect("/main");
+  }
+
   return (
-    <div className={"h-[100svh] flex flex-col items-center justify-center"}>
-      <div className={"text-3xl mb-5"}>
-        모아노트 로그인
-      </div>
-      <form className="flex flex-col w-[300px] max-w-sm mx-auto p-4"
-            method="POST"
-            action="/api/auth/login">
-        <input type="text" name="redirect" value="/main" hidden readOnly/>
-        <input type="text" name="username" placeholder="Username" className="w-full mb-2 border p-2 rounded" required/>
-        <input type="password" name="password" placeholder="Password" className="w-full mb-8 border p-2 rounded" required/>
-        <button type="submit" className="bg-blue-500 text-white p-2 rounded cursor-pointer">Login</button>
-      </form>
-    </div>)
+    <div>
+      <p>로그인 페이지로 이동 중...</p>
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,21 @@
-import { fetchCurrentUserServerSide } from "@/libs/server/user";
-import { redirect } from "next/navigation";
+import TopNavigationBar from "@/components/layout/Home/TopNavigationBar";
+import Main from "@/components/layout/Home/Main"
+import BasicIntroduce from "@/components/layout/Home/BasicIntroduce"
+import MoaAIIntroduce from "@/components/layout/Home/MoaAIIntroduce"
+import Final from "@/components/layout/Home/Final"
+import ContactLinkBar from "@/components/layout/Home/ContactLinkBar"
 
-const LOGIN_URL = process.env.NEXT_PUBLIC_LOGIN_URL;
-
-export default async function RootPage() {
-
-  const user = await fetchCurrentUserServerSide();
-
-  if (!user) {
-    // 미로그인시 백엔드 로그인 페이지로 이동
-    if (LOGIN_URL)
-      redirect(LOGIN_URL);
-  } else {
-    // 로그인 되어있으면 /main 으로 이동
-    redirect("/main");
-  }
-
-  return <div>
-
-  </div>;
+export default function RootPage() {
+  return (
+    <div>
+      <div className="flex flex-col justify-start items-center w-full relative gap-[59px] bg-[#f0f8fe]">
+        <TopNavigationBar />
+        <Main />
+        <BasicIntroduce />
+        <MoaAIIntroduce />
+        <Final />
+        <ContactLinkBar />
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## 수행한 작업
### feature
- 홈 화면(모아노트 실행 시 첫 화면)에서 상단 로그인 버튼 혹은 화면의 시작하기 버튼 클릭 시, 백엔드 로그인 서버로 리다이렉트 됨.