### PR TITLE
[Feature] caret jumping 문제를 해결하기 위해 textarea 대신 contentEditable 기능을 이용하도록 수정

### DIFF
--- a/src/components/document/TreeBasedDocumentRenderer.tsx
+++ b/src/components/document/TreeBasedDocumentRenderer.tsx
@@ -19,7 +19,6 @@ export default function DocumentRenderer({user, uuid}: { user:User, uuid: string
   const [isEditing, setEditing] = useState<boolean>(false); // 현재 편집중인가?
   const [cursorPosition, setCursorPosition] = useState<number>(0); // 커서 위치
   const startEditing = () => setEditing(true);
-  const endEditing = () => setEditing(false);
 
   const clientRef = useRef<Client | null>(null);
   const textNoteSegmentsRef = useRef<TextNoteSegmentDTO[]>([]);
@@ -134,7 +133,6 @@ export default function DocumentRenderer({user, uuid}: { user:User, uuid: string
       {isEditing ? (
         <TreeMarkdownEditor
           initialContent={document.content}
-          updateBlur={endEditing}
           updateContent={(newContent: string) => {
             const diff = getDiff(document.content, newContent);
 

--- a/src/components/document/TreeBasedDocumentRenderer.tsx
+++ b/src/components/document/TreeBasedDocumentRenderer.tsx
@@ -7,7 +7,6 @@ import {MarkdownRenderer} from "@/components/document/MarkdownRenderer";
 import {TreeNote} from "@/libs/structures/treenote";
 import getDiff from "@/libs/simpledDiff";
 import {CRDTOperation} from "@/types/crdtOperation";
-import useFugueDocumentSync from "@/hooks/useFugueDocumentSync";
 import {TextNoteSegmentDTO} from "@/types/dto";
 import {Client} from "@stomp/stompjs";
 import toast from "react-hot-toast"

--- a/src/components/document/TreeMarkdownEditor.tsx
+++ b/src/components/document/TreeMarkdownEditor.tsx
@@ -12,12 +12,11 @@ import TextareaAutosize from "react-textarea-autosize";
  * @param cursorHandler 커서 위치를 상위 컴포넌트로 전달하는 콜백 (optional)
  * @constructor
  */
-export function TreeMarkdownEditor({initialContent = null, updateContent = null, updateBlur = null, lastCursorPosition = null, cursorHandler = null}: {
+export function TreeMarkdownEditor({initialContent = null, updateContent, lastCursorPosition, cursorHandler}: {
   initialContent: string | null | undefined,
-  updateContent?: null | ((content: string) => void),
-  updateBlur?: null | (() => void),
-  lastCursorPosition?: number | null | undefined,
-  cursorHandler?: null | ((cursor: number) => void)
+  updateContent: (content: string) => void,
+  lastCursorPosition: SelectionRange,
+  cursorHandler: ((cursor: SelectionRange) => void)
 }) {
 
   const [cursorPosition, setCursor] = useState(lastCursorPosition ? lastCursorPosition : 0);

--- a/src/components/document/TreeMarkdownEditor.tsx
+++ b/src/components/document/TreeMarkdownEditor.tsx
@@ -1,13 +1,106 @@
-import invariant from 'tiny-invariant';
 import {useEffect, useRef, useState} from "react";
-import TextareaAutosize from "react-textarea-autosize";
-//import toast from "react-hot-toast";
+import {SelectionRange} from "@/types/selectionRange";
+
+/*
+ * 각 줄의 시작과 끝에서 caret 을 1 만큼 이동할 때에 (주로 shift + 방향키를 통해서 이러한 이동을 함)
+ * 실제 caret 이동이 의도하지 않은 위치로 이동하는 문제가 있음
+ */
+
+function selectionToIndex(element: HTMLElement, selection: Selection): SelectionRange {
+  let baseOffset = 0;
+  let extentOffset = 0;
+  let currectOffset = 0;
+
+  function walk(node: Node) {
+    if (node === selection.baseNode) {
+      baseOffset = currectOffset + selection.baseOffset;
+    }
+    if (node === selection.extentNode) {
+      extentOffset = currectOffset + selection.extentOffset;
+      return;
+    }
+    if (node.nodeType === Node.TEXT_NODE) {
+      currectOffset += node.nodeValue?.length || 0;
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      if (node.tagName === 'BR') {
+        currectOffset++;
+      }
+    }
+    for (let i = 0; i < node.childNodes.length; i++) {
+      walk(node.childNodes[i]);
+    }
+  }
+
+  walk(element);
+  return {baseOffset, extentOffset};
+}
+
+function indexToRange(element: HTMLElement, baseOffset: number, extentOffset: number): Range {
+  const range = document.createRange();
+  let currentOffset = 0;
+  let baseNode: Node | null = null;
+  let baseNodeOffset = 0;
+  let extentNode: Node | null = null;
+  let extentNodeOffset = 0;
+
+  function walk(node: Node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const textLength = node.nodeValue?.length || 0;
+      if (currentOffset + textLength >= baseOffset && !baseNode) {
+        baseNode = node;
+        baseNodeOffset = baseOffset - currentOffset;
+      }
+      if (currentOffset + textLength >= extentOffset && !extentNode) {
+        extentNode = node;
+        extentNodeOffset = extentOffset - currentOffset;
+      }
+      currentOffset += textLength;
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      if (node.tagName === 'BR') {
+        currentOffset++;
+      }
+    }
+    for (let i = 0; i < node.childNodes.length; i++) {
+      walk(node.childNodes[i]);
+    }
+  }
+
+  walk(element);
+
+  if (baseNode && extentNode) {
+    range.setStart(baseNode, baseNodeOffset);
+    range.setEnd(extentNode, extentNodeOffset);
+  }
+
+  return range;
+}
+
+function getSelectionRangeIndex(element: HTMLElement): SelectionRange {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return {baseOffset: 0, extentOffset: 0};
+
+  return selectionToIndex(element, selection);
+}
+
+function setSelectionRangeCaret(element: HTMLElement, baseOffset: number, extentOffset: number) {
+  if (element.childNodes.length == 0)
+    return;
+
+  debugger;
+  const range = indexToRange(element, baseOffset, extentOffset);
+
+  const newRange = indexToRange(element, baseOffset, extentOffset);
+
+  const selection = document.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(newRange);
+  selection?.setBaseAndExtent(range.startContainer, range.startOffset, range.endContainer, range.endOffset);
+}
 
 /**
  * 마크다운 에디터
  * @param initialContent 초기 내용
  * @param updateContent 에디터에서 내용 업데이트할 때 콜백 (optional)
- * @param updateBlur 사용자가 에디터의 포커스를 잃었을 때 콜백 (optional)
  * @param lastCursorPosition 커서 위치 초기값
  * @param cursorHandler 커서 위치를 상위 컴포넌트로 전달하는 콜백 (optional)
  * @constructor
@@ -19,50 +112,81 @@ export function TreeMarkdownEditor({initialContent = null, updateContent, lastCu
   cursorHandler: ((cursor: SelectionRange) => void)
 }) {
 
-  const [cursorPosition, setCursor] = useState(lastCursorPosition ? lastCursorPosition : 0);
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
 
-  const handleSelect = () => {
-    const el = textAreaRef.current;
-    invariant(el, "textAreaRef is null");
-    if (!el)
-      return;
-    setCursor(el.selectionStart);
-    if (cursorHandler)
-      cursorHandler(el.selectionStart);
-  }
+  const selectionRange = lastCursorPosition ? lastCursorPosition : {baseOffset: 0, extentOffset: 0};
 
+  // 입력 시 텍스트 및 커서/선택 범위 저장
+  const handleInput = () => {
+    const el = editorRef.current;
+    if (!el) return;
+
+    updateContent(el.innerText);
+    const range = getSelectionRangeIndex(el);
+    cursorHandler(range);
+  };
+
+  // 선택 변경 시 selection 범위 업데이트
+  const handleSelectionChange = () => {
+    debugger;
+    const el = editorRef.current;
+    if (!el || document.activeElement !== el) return;
+
+    const range = getSelectionRangeIndex(el);
+    cursorHandler(range);
+  };
+
+  // 붙여넣기 처리
+  const handlePaste = (e) => {
+    e.preventDefault();
+    const text = e.clipboardData?.getData('text/plain');
+    document.execCommand('insertText', false, text ? text : '');
+  };
+
+  // content 가 바뀌면 내부 반영
   useEffect(() => {
-    if (textAreaRef.current) {
-      textAreaRef.current.focus();
-      textAreaRef.current.setSelectionRange(cursorPosition, cursorPosition);
+    const el = editorRef.current;
+    if (el && el.innerText !== initialContent) {
+      el.innerText = initialContent ? initialContent : '';
+      setSelectionRangeCaret(el, selectionRange.baseOffset, selectionRange.extentOffset);
     }
-  }, [cursorPosition, textAreaRef]);
+  }, [initialContent]);
 
-  const handleChange = () => {
-    const el = textAreaRef.current;
-    if (el && updateContent) {
-      updateContent(el.value);
+  // selectionRange 가 바뀌면 반영
+  useEffect(() => {
+    const el = editorRef.current;
+    if (el) {
+      setSelectionRangeCaret(el, selectionRange.baseOffset, selectionRange.extentOffset);
     }
-  }
+  }, [selectionRange.baseOffset, selectionRange.extentOffset]);
 
-  const handleBlur = () => {
-    if (updateBlur)
-      updateBlur();
-  }
+  // selectionchange 감지
+  useEffect(() => {
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => {
+      document.removeEventListener('selectionchange', handleSelectionChange);
+    };
+  }, []);
 
   return (
     <div className="w-full">
-      <TextareaAutosize
+      <div
         className="w-full border p-2 rounded-xl"
-        minRows={5}
-        placeholder={"Type Document Here..."}
-        value={initialContent ? initialContent : ""}
-        onBlur={handleBlur}
-        onChange={handleChange}
-        onSelect={handleSelect}
-        ref={textAreaRef}
-        autoFocus={true}/>
+        ref={editorRef}
+        contentEditable
+        onInput={handleInput}
+        onPaste={handlePaste}
+        suppressContentEditableWarning
+        style={{
+          border: '1px solid #ccc',
+          padding: '10px',
+          borderRadius: '8px',
+          minHeight: '100px',
+          fontSize: '16px',
+          whiteSpace: 'pre-wrap',
+          outline: 'none',
+        }}
+      />
     </div>
   );
 }

--- a/src/types/selectionRange.d.ts
+++ b/src/types/selectionRange.d.ts
@@ -1,0 +1,4 @@
+export interface SelectionRange {
+  baseOffset: number;
+  extentOffset: number;
+}


### PR DESCRIPTION
## 수행한 작업
### chore
- 사용하지 않는 import useFugueDocumentSync 문 제거 542761a986eefbc521c796e03de40140ce753db7
### refactor
- 사용되지 않는 플래그 변수 endEditing 제거 및 파라미터의 optional 특성 제거 299658f13e6f542f108043deb4b443b43f7907bc
### feat
- 기존 textarea 를 활용한 텍스트 에디터 컴포넌트를 contentEditable 을 이용한 수정이 가능하도록 변경 58bf0e69d867d3e86f3c9cb636bc20b33b5a9a50

## 설명
- 동시 편집 시 caret jumping 문제 해결을 위해 textarea 대신 contentEditable 을 이용하도록 재구현함
- contentEditable 을 사용하였으므로 기존에 텍스트 입력만 가능하던 에디터 대신, 다양한 기능 및 UI 를 추가할 수 있음

## 관련 이슈
- #59 문제가 여전히 있는 것으로 보임