### PR TITLE
[Bug] http response 처리 시 본문이 있는 경우에도 본문을 무시하는 경우가 있는 오류 수정

### DIFF
--- a/src/libs/client/file.ts
+++ b/src/libs/client/file.ts
@@ -43,6 +43,7 @@ async function getRequest(location: string) {
  * 백엔드에 POST로 API 호출하는 함수 (client-side)
  * @param location API 호출할 relative-location
  * @param stringifiedBody JSON stringified body
+ * @return 응답 본문이 있으면 파싱된 JSON, 그렇지 않은 경우 요청 성공 여부 (true/false)
  */
 async function postRequest(location: string, stringifiedBody?: string) {
   console.log("post요청 location:", location);
@@ -59,18 +60,13 @@ async function postRequest(location: string, stringifiedBody?: string) {
 
   console.log(`postRequest[${res.status}]: ${location}`);
 
-  if (!res.ok) {
-    return null;
-  }
-
-  // 응답 본문이 없으면 true 반환
-  const contentLength = res.headers.get("content-length");
-  if (!contentLength || contentLength === "0") {
-    return true;
-  }
 
   // 본문이 있으면 json 파싱
-  return await res.json();
+  const responseBody = await res.json();
+  if (!responseBody)
+    return res.ok;
+  else
+    return responseBody;
 }
 
 /**


### PR DESCRIPTION
### 설명
- 기존 코드는 response body 의 존재 여부를 `content-length` 헤더만으로 판별하였음
- 실제로는 위 헤더가 없더라도 body 가 존재할 수 있음
- 또한 요청이 실패한 경우에는 항상 null 을 반환했지만, 실제로는 실패한 경우에도 body 가 필요할 수 있음
- 따라서 위의 오류를 해결하며 함수의 반환값 스펙을 명시하였음